### PR TITLE
fixed Inconsistent handling of songIndex and misc

### DIFF
--- a/script.js
+++ b/script.js
@@ -51,7 +51,7 @@ masterPlay.addEventListener('click', () => {
 audioElement.addEventListener('timeupdate', () => {
 
     //update SeekBar
-    progress = parseInt((audioElement.currentTime / audioElement.duration * 100));
+    let progress = parseInt((audioElement.currentTime / audioElement.duration * 100));
     myProgressBar.value = progress;
 })
 myProgressBar.addEventListener('change', () => {
@@ -80,11 +80,7 @@ Array.from(document.getElementsByClassName('songItemPlay')).forEach((element) =>
     })
 })
 document.getElementById('next').addEventListener('click', () => {
-    if (songIndex >= 19) {
-        songIndex = 0;
-    } else {
-        songIndex += 1;
-    }
+    songIndex = (songIndex + 1) % songs.length;
     //audioElement.src = `Songs/${songIndex + 1}.mp3`;
     audioElement.src = songs[songIndex].filePath;
     masterSongName.innerText = songs[songIndex].songName;
@@ -95,11 +91,7 @@ document.getElementById('next').addEventListener('click', () => {
 
 })
 document.getElementById('previous').addEventListener('click', () => {
-    if (songIndex <= 0) {
-        songIndex = 0;
-    } else {
-        songIndex -= 1;
-    }
+    songIndex = (songIndex - 1 + songs.length) % songs.length;
     //audioElement.src = `Songs/${songIndex + 1}.mp3`;
     audioElement.src = songs[songIndex].filePath;
     masterSongName.innerText = songs[songIndex].songName; 


### PR DESCRIPTION
 The 'next' and 'previous' event listeners don't handle the songIndex correctly. When moving to the previous song, the code sets songIndex to 0 if it's less than or equal to 0, which means it'll always restart from the first song. Instead, it should loop back to the last song when reaching the first one. Similarly, the 'next' button also has a similar issue when reaching the last song.
Similarly, In the 'timeupdate' event listener, the progress variable is not defined before using it. To prevent any issues, declare progress before updating its value: